### PR TITLE
changed names in robot map

### DIFF
--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -36,30 +36,30 @@ public class RobotMap {
   }
 
   public static class mapClimber {
-    public static final int CLIMBER_CAN = 20;
-    public static final int CLIMBER_CAN_2 = 21;
+    public static final int CLIMBER_LEFT_CAN = 20;
+    public static final int CLIMBER_RIGHT_CAN = 21;
   }
 
   public static class mapAlgaeIntake {
-    public static final int ALGAE_MOTOR_ONE_CAN = 10;
-    public static final int ALGAE_MOTOR_TWO_CAN = 11;
+    public static final int INTAKE_LEFT_MOTOR_CAN = 10;
+    public static final int INTAKE_RIGHT_MOTOR_CAN = 11;
     public static final int ALGAE_SENSOR_CAN = 12;
   }
 
   public static class mapCoralOuttake {
-    public static final int CORAL_OUTTAKE_MOTOR_CAN = 30;
-    public static final int CORAL_OUTTAKE_MOTOR_CAN_2 = 31;
+    public static final int CORAL_OUTTAKE_LEFT_MOTOR_CAN = 30;
+    public static final int CORAL_OUTTAKE_RIGHT_MOTOR_CAN = 31;
     public static final int CORAL_SENSOR_CAN = 32;
   }
 
   // Hopper is 40-49
   public static class mapHopper {
     public static final int HOPPER_MOTOR_CAN = 40;
-    public static final int HOPPER_SENSOR_DIO = 0;
+    public static final int HOPPER_SENSOR_CAN = 0;
   }
 
   public static class mapElevator {
-    public static final int LEFT_ELEVATOR_CAN = 50;
-    public static final int RIGHT_ELEVATOR_CAN = 51;
+    public static final int ELEVATOR_LEFT_CAN = 50;
+    public static final int ELEVATOR_RIGHT_CAN = 51;
   }
 }

--- a/src/main/java/frc/robot/subsystems/AlgaeIntake.java
+++ b/src/main/java/frc/robot/subsystems/AlgaeIntake.java
@@ -20,8 +20,8 @@ public class AlgaeIntake extends SubsystemBase {
 
   /** Creates a new AlgaeIntake. */
   public AlgaeIntake() {
-    intakeMotorOne = new TalonFX(mapAlgaeIntake.ALGAE_MOTOR_ONE_CAN);
-    intakeMotorTwo = new TalonFX(mapAlgaeIntake.ALGAE_MOTOR_TWO_CAN);
+    intakeMotorOne = new TalonFX(mapAlgaeIntake.INTAKE_LEFT_MOTOR_CAN);
+    intakeMotorTwo = new TalonFX(mapAlgaeIntake.INTAKE_RIGHT_MOTOR_CAN);
 
     intakeMotorOne.getConfigurator().apply(constAlgaeIntake.ALGAE_INTAKE_CONFIG);
     intakeMotorTwo.getConfigurator().apply(constAlgaeIntake.ALGAE_INTAKE_CONFIG);

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -17,8 +17,8 @@ public class Climber extends SubsystemBase {
   TalonFX climberMotor2;
 
   public Climber() {
-    climberMotor = new TalonFX(RobotMap.mapClimber.CLIMBER_CAN);
-    climberMotor2 = new TalonFX(RobotMap.mapClimber.CLIMBER_CAN_2);
+    climberMotor = new TalonFX(RobotMap.mapClimber.CLIMBER_LEFT_CAN);
+    climberMotor2 = new TalonFX(RobotMap.mapClimber.CLIMBER_RIGHT_CAN);
   }
 
   public void setClimberMotorVelocity(double velocity) {

--- a/src/main/java/frc/robot/subsystems/CoralOuttake.java
+++ b/src/main/java/frc/robot/subsystems/CoralOuttake.java
@@ -14,6 +14,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.constCoralOuttake;
 import frc.robot.RobotMap.mapCoralOuttake;
+
 @Logged
 public class CoralOuttake extends SubsystemBase {
   TalonFX outtakeMotor;
@@ -22,8 +23,8 @@ public class CoralOuttake extends SubsystemBase {
 
   /** Creates a new CoralOuttake. */
   public CoralOuttake() {
-    outtakeMotor = new TalonFX(mapCoralOuttake.CORAL_OUTTAKE_MOTOR_CAN);
-    outtakeMotor2 = new TalonFX(mapCoralOuttake.CORAL_OUTTAKE_MOTOR_CAN_2);
+    outtakeMotor = new TalonFX(mapCoralOuttake.CORAL_OUTTAKE_LEFT_MOTOR_CAN);
+    outtakeMotor2 = new TalonFX(mapCoralOuttake.CORAL_OUTTAKE_RIGHT_MOTOR_CAN);
     coralSensor = new CANrange(mapCoralOuttake.CORAL_SENSOR_CAN);
 
     configure();

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -17,6 +17,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.constElevator;
 import frc.robot.RobotMap.mapElevator;
+
 @Logged
 public class Elevator extends SubsystemBase {
   private TalonFX leftMotorFollower;
@@ -24,8 +25,8 @@ public class Elevator extends SubsystemBase {
 
   /** Creates a new Elevator. */
   public Elevator() {
-    leftMotorFollower = new TalonFX(mapElevator.LEFT_ELEVATOR_CAN);
-    rightMotorLeader = new TalonFX(mapElevator.RIGHT_ELEVATOR_CAN);
+    leftMotorFollower = new TalonFX(mapElevator.ELEVATOR_LEFT_CAN);
+    rightMotorLeader = new TalonFX(mapElevator.ELEVATOR_RIGHT_CAN);
 
     configure();
   }

--- a/src/main/java/frc/robot/subsystems/Hopper.java
+++ b/src/main/java/frc/robot/subsystems/Hopper.java
@@ -21,7 +21,7 @@ public class Hopper extends SubsystemBase {
   /** Creates a new hopper. */
   public Hopper() {
     hopperMotor = new TalonFX(mapHopper.HOPPER_MOTOR_CAN);
-    hopperSensor = new DigitalInput(mapHopper.HOPPER_SENSOR_DIO);
+    hopperSensor = new DigitalInput(mapHopper.HOPPER_SENSOR_CAN);
 
     hopperMotor.getConfigurator().apply(constHopper.HOPPER_CONFIG);
 


### PR DESCRIPTION
This pull request focuses on renaming constants in the `RobotMap` class for better clarity and consistency. The changes affect various subsystems including the climber, algae intake, coral outtake, elevator, and hopper. The most important changes include renaming motor and sensor constants to follow a more consistent naming convention.

Renaming constants for better clarity:

* [`src/main/java/frc/robot/RobotMap.java`](diffhunk://#diff-76a5871e61775825d04a4280419a38fa008b74b8298e661a2f6d694728d54188L39-R63): Renamed constants in `mapClimber`, `mapAlgaeIntake`, `mapCoralOuttake`, `mapHopper`, and `mapElevator` classes to use more descriptive names.

Updating subsystem classes to use renamed constants:

* [`src/main/java/frc/robot/subsystems/Climber.java`](diffhunk://#diff-1000d31648c1ff8b42b5deec3bee8047af990c42a3ff199d5ed9423a8046aaf3L20-R21): Updated to use `CLIMBER_LEFT_CAN` and `CLIMBER_RIGHT_CAN` instead of the old constants.
* [`src/main/java/frc/robot/subsystems/AlgaeIntake.java`](diffhunk://#diff-69352153343af0dd972c2512b31bd7651c6f51d77ed58735b779e3e4740dfe2fL23-R24): Updated to use `INTAKE_LEFT_MOTOR_CAN` and `INTAKE_RIGHT_MOTOR_CAN` instead of the old constants.
* [`src/main/java/frc/robot/subsystems/CoralOuttake.java`](diffhunk://#diff-0f80eee04f2987bc4e931ad706eb4f5aab412868475f97336387505afd16eaf6L25-R27): Updated to use `CORAL_OUTTAKE_LEFT_MOTOR_CAN` and `CORAL_OUTTAKE_RIGHT_MOTOR_CAN` instead of the old constants.
* [`src/main/java/frc/robot/subsystems/Elevator.java`](diffhunk://#diff-8aa0929510600970730d4673a6762df0ea3556551b46be4e13fa5005364acaa3R20-R29): Updated to use `ELEVATOR_LEFT_CAN` and `ELEVATOR_RIGHT_CAN` instead of the old constants.
* [`src/main/java/frc/robot/subsystems/Hopper.java`](diffhunk://#diff-3a819467f7e8efaac8c773ef615eb98ada4127ed8a4cd7620c50d3dabc9f5b41L24-R24): Updated to use `HOPPER_SENSOR_CAN` instead of the old constant.