### PR TITLE
Removed Unneeded Configure

### DIFF
--- a/src/main/java/frc/robot/subsystems/CoralOuttake.java
+++ b/src/main/java/frc/robot/subsystems/CoralOuttake.java
@@ -26,8 +26,6 @@ public class CoralOuttake extends SubsystemBase {
     outtakeMotor = new TalonFX(mapCoralOuttake.CORAL_OUTTAKE_LEFT_MOTOR_CAN);
     outtakeMotor2 = new TalonFX(mapCoralOuttake.CORAL_OUTTAKE_RIGHT_MOTOR_CAN);
     coralSensor = new CANrange(mapCoralOuttake.CORAL_SENSOR_CAN);
-
-    configure();
   }
 
   public void configure() {

--- a/src/main/java/frc/robot/subsystems/CoralOuttake.java
+++ b/src/main/java/frc/robot/subsystems/CoralOuttake.java
@@ -26,9 +26,7 @@ public class CoralOuttake extends SubsystemBase {
     outtakeMotor = new TalonFX(mapCoralOuttake.CORAL_OUTTAKE_LEFT_MOTOR_CAN);
     outtakeMotor2 = new TalonFX(mapCoralOuttake.CORAL_OUTTAKE_RIGHT_MOTOR_CAN);
     coralSensor = new CANrange(mapCoralOuttake.CORAL_SENSOR_CAN);
-  }
 
-  public void configure() {
     outtakeMotor.getConfigurator().apply(constCoralOuttake.CORAL_OUTTAKE_CONFIG);
     outtakeMotor2.getConfigurator().apply(constCoralOuttake.CORAL_OUTTAKE_CONFIG);
   }

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -32,9 +32,7 @@ public class Elevator extends SubsystemBase {
     rightMotorLeader = new TalonFX(mapElevator.ELEVATOR_RIGHT_CAN);
 
     lastDesiredPosition = Units.Inches.of(0);
-  }
-
-  public void configure() {
+    
     rightMotorLeader.getConfigurator().apply(constElevator.ELEVATOR_CONFIG);
     leftMotorFollower.getConfigurator().apply(constElevator.ELEVATOR_CONFIG);
   }

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -32,8 +32,6 @@ public class Elevator extends SubsystemBase {
     rightMotorLeader = new TalonFX(mapElevator.ELEVATOR_RIGHT_CAN);
 
     lastDesiredPosition = Units.Inches.of(0);
-
-    configure();
   }
 
   public void configure() {


### PR DESCRIPTION
This pull request includes changes to the constructors of two classes in the `src/main/java/frc/robot/subsystems` directory. The changes involve removing the calls to the `configure` method from the constructors of the `CoralOuttake` and `Elevator` classes.

Changes to constructors:

* [`src/main/java/frc/robot/subsystems/CoralOuttake.java`](diffhunk://#diff-0f80eee04f2987bc4e931ad706eb4f5aab412868475f97336387505afd16eaf6L29-L30): Removed the call to the `configure` method from the `public CoralOuttake()` constructor.
* [`src/main/java/frc/robot/subsystems/Elevator.java`](diffhunk://#diff-8aa0929510600970730d4673a6762df0ea3556551b46be4e13fa5005364acaa3L35-L36): Removed the call to the `configure` method from the `public Elevator()` constructor.