### PR TITLE
Fixed The Issue (I Think)

### DIFF
--- a/src/main/java/frc/robot/commands/states/HasCoral.java
+++ b/src/main/java/frc/robot/commands/states/HasCoral.java
@@ -41,6 +41,6 @@ public class HasCoral extends Command {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return globalCoralOuttake.hasCoral();
+    return true;
   }
 }


### PR DESCRIPTION
This pull request includes a small change to the `HasCoral` command. The change modifies the `isFinished` method to always return `true` instead of checking if `globalCoralOuttake.hasCoral()`.

* [`src/main/java/frc/robot/commands/states/HasCoral.java`](diffhunk://#diff-66bbe2819f236d4b9b74e06d976c63ab53aea7733c21ca2030fe39f39b0bae74L44-R44): Modified the `isFinished` method to return `true` unconditionally.