### PR TITLE
Removed Unneeded Comment

### DIFF
--- a/src/main/java/frc/robot/commands/states/HasAlgae.java
+++ b/src/main/java/frc/robot/commands/states/HasAlgae.java
@@ -37,7 +37,6 @@ public class HasAlgae extends Command {
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
-    // globalAlgaeIntake.setAlgaeIntakeMotor(constAlgaeIntake.HAS_ALGAE_INTAKE_SPEED);
     globalAlgaeIntake.setAlgaeIntakeVoltage(constAlgaeIntake.HOLD_ALGAE_INTAKE_VOLTAGE);
   }
 


### PR DESCRIPTION
This pull request includes a change to the `HasAlgae` command to update the motor control logic when the command ends.

* [`src/main/java/frc/robot/commands/states/HasAlgae.java`](diffhunk://#diff-4cdf7241394f5a3630d68a47b3ef9ea1dc42e81890b7cb370ea7c0f4083b84e4L40): Removed the line that sets the algae intake motor speed and replaced it with a line that sets the algae intake voltage to hold the algae.