### PR TITLE
Migrated Auto Commands to Using Commands

### DIFF
--- a/simgui.json
+++ b/simgui.json
@@ -10,7 +10,19 @@
     "types": {
       "/FMSInfo": "FMSInfo",
       "/SmartDashboard/Alerts": "Alerts",
-      "/SmartDashboard/Field": "Field2d"
+      "/SmartDashboard/Field": "Field2d",
+      "/SmartDashboard/SendableChooser[0]": "String Chooser",
+      "Robot/m_robotContainer/autoChooser": "String Chooser",
+      "Robot/m_robotContainer/subAlgaeIntake/intakeMotorOne": "Motor Controller",
+      "Robot/m_robotContainer/subAlgaeIntake/intakeMotorTwo": "Motor Controller",
+      "Robot/m_robotContainer/subClimber/climberMotor": "Motor Controller",
+      "Robot/m_robotContainer/subClimber/climberMotor2": "Motor Controller",
+      "Robot/m_robotContainer/subCoralOuttake/outtakeMotor": "Motor Controller",
+      "Robot/m_robotContainer/subCoralOuttake/outtakeMotor2": "Motor Controller",
+      "Robot/m_robotContainer/subElevator/leftMotorFollower": "Motor Controller",
+      "Robot/m_robotContainer/subElevator/rightMotorLeader": "Motor Controller",
+      "Robot/m_robotContainer/subHopper/hopperMotor": "Motor Controller",
+      "Robot/m_robotContainer/subHopper/hopperSensor": "Digital Input"
     },
     "windows": {
       "/SmartDashboard/Field": {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -131,7 +131,7 @@ public class RobotContainer {
 
   private void configureAutoBindings() {
     NamedCommands.registerCommand("PrepPlace",
-        Commands.sequence(TRY_PREP_CORAL_L3));
+        Commands.sequence(TRY_PREP_CORAL_L3).asProxy());
 
     NamedCommands.registerCommand("PlaceSequence",
         Commands.sequence(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -135,17 +135,17 @@ public class RobotContainer {
 
     NamedCommands.registerCommand("PlaceSequence",
         Commands.sequence(
-            TRY_SCORING_CORAL.until(() -> !hasCoralTrigger.getAsBoolean())),
+            TRY_SCORING_CORAL.until(() -> !hasCoralTrigger.getAsBoolean()),
             Commands.waitSeconds(1.5),
-            TRY_NONE.until(() -> !hasCoralTrigger.getAsBoolean()))));
+            TRY_NONE.until(() -> !hasCoralTrigger.getAsBoolean())));
 
     NamedCommands.registerCommand("PrepCoralStation",
         Commands.print("Prep Coral Station"));
 
     NamedCommands.registerCommand("GetCoralStationPiece",
         Commands.sequence(
-            TRY_INTAKING_CORAL_HOPPER.until(hasCoralTrigger)),
-            TRY_PREP_CORAL_L3);
+            TRY_INTAKING_CORAL_HOPPER.until(hasCoralTrigger),
+            TRY_PREP_CORAL_L3));
   }
 
   private void configureDriverBindings(SN_XboxController controller) {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -137,7 +137,7 @@ public class RobotContainer {
         Commands.sequence(
             TRY_SCORING_CORAL.asProxy().until(() -> !hasCoralTrigger.getAsBoolean()),
             Commands.waitSeconds(1.5),
-            TRY_NONE.asProxy().until(() -> !hasCoralTrigger.getAsBoolean())).asProxy());
+            TRY_NONE.asProxy().until(() -> !hasCoralTrigger.getAsBoolean())));
 
     NamedCommands.registerCommand("PrepCoralStation",
         Commands.print("Prep Coral Station"));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -131,7 +131,7 @@ public class RobotContainer {
 
   private void configureAutoBindings() {
     NamedCommands.registerCommand("PrepPlace",
-        Commands.sequence(TRY_PREP_CORAL_L3).asProxy());
+        Commands.sequence(TRY_PREP_CORAL_L3.asProxy()));
 
     NamedCommands.registerCommand("PlaceSequence",
         Commands.sequence(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -137,7 +137,7 @@ public class RobotContainer {
         Commands.sequence(
             TRY_SCORING_CORAL.until(() -> !hasCoralTrigger.getAsBoolean()),
             Commands.waitSeconds(1.5),
-            TRY_NONE.until(() -> !hasCoralTrigger.getAsBoolean())));
+            TRY_NONE.until(() -> !hasCoralTrigger.getAsBoolean())).asProxy());
 
     NamedCommands.registerCommand("PrepCoralStation",
         Commands.print("Prep Coral Station"));
@@ -145,7 +145,7 @@ public class RobotContainer {
     NamedCommands.registerCommand("GetCoralStationPiece",
         Commands.sequence(
             TRY_INTAKING_CORAL_HOPPER.until(hasCoralTrigger),
-            TRY_PREP_CORAL_L3));
+            TRY_PREP_CORAL_L3).asProxy());
   }
 
   private void configureDriverBindings(SN_XboxController controller) {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -131,27 +131,21 @@ public class RobotContainer {
 
   private void configureAutoBindings() {
     NamedCommands.registerCommand("PrepPlace",
-        Commands.sequence(
-            Commands.deferredProxy(
-                () -> subStateMachine.tryState(RobotState.PREP_CORAL_L3))));
+        Commands.sequence(TRY_PREP_CORAL_L3));
 
     NamedCommands.registerCommand("PlaceSequence",
         Commands.sequence(
-            Commands.deferredProxy(
-                () -> subStateMachine.tryState(RobotState.SCORING_CORAL).until(() -> !hasCoralTrigger.getAsBoolean())),
+            TRY_SCORING_CORAL.until(() -> !hasCoralTrigger.getAsBoolean())),
             Commands.waitSeconds(1.5),
-            Commands.deferredProxy(
-                () -> subStateMachine.tryState(RobotState.NONE).until(() -> !hasCoralTrigger.getAsBoolean()))));
+            TRY_NONE.until(() -> !hasCoralTrigger.getAsBoolean()))));
 
     NamedCommands.registerCommand("PrepCoralStation",
         Commands.print("Prep Coral Station"));
 
     NamedCommands.registerCommand("GetCoralStationPiece",
         Commands.sequence(
-            Commands
-                .deferredProxy(() -> subStateMachine.tryState(RobotState.INTAKING_CORAL_HOPPER).until(hasCoralTrigger)),
-            Commands.deferredProxy(
-                () -> subStateMachine.tryState(RobotState.PREP_CORAL_L3))));
+            TRY_INTAKING_CORAL_HOPPER.until(hasCoralTrigger)),
+            TRY_PREP_CORAL_L3);
   }
 
   private void configureDriverBindings(SN_XboxController controller) {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -135,17 +135,17 @@ public class RobotContainer {
 
     NamedCommands.registerCommand("PlaceSequence",
         Commands.sequence(
-            TRY_SCORING_CORAL.until(() -> !hasCoralTrigger.getAsBoolean()),
+            TRY_SCORING_CORAL.asProxy().until(() -> !hasCoralTrigger.getAsBoolean()),
             Commands.waitSeconds(1.5),
-            TRY_NONE.until(() -> !hasCoralTrigger.getAsBoolean())).asProxy());
+            TRY_NONE.asProxy().until(() -> !hasCoralTrigger.getAsBoolean())).asProxy());
 
     NamedCommands.registerCommand("PrepCoralStation",
         Commands.print("Prep Coral Station"));
 
     NamedCommands.registerCommand("GetCoralStationPiece",
         Commands.sequence(
-            TRY_INTAKING_CORAL_HOPPER.until(hasCoralTrigger),
-            TRY_PREP_CORAL_L3).asProxy());
+          TRY_INTAKING_CORAL_HOPPER.asProxy().until(hasCoralTrigger),
+          TRY_PREP_CORAL_L3.asProxy()));
   }
 
   private void configureDriverBindings(SN_XboxController controller) {

--- a/src/main/java/frc/robot/subsystems/StateMachine.java
+++ b/src/main/java/frc/robot/subsystems/StateMachine.java
@@ -237,7 +237,7 @@ public class StateMachine extends SubsystemBase {
         }
         break;
     }
-    return Commands.print("ITS SO OVER D: Invalid State Provided (╯‵□′)╯︵┻━┻");
+    return Commands.print("ITS SO OVER D: Invalid State Provided, Blame Eli");
   }
 
   public static enum RobotState {


### PR DESCRIPTION
This pull request includes several changes to the `simgui.json` file and the Java codebase for the robot's state machine and command registration. The most important changes include the addition of new entries in `simgui.json`, refactoring of command sequences in `RobotContainer.java`, and updating a debug message in `StateMachine.java`.

### Configuration updates:
* [`simgui.json`](diffhunk://#diff-13ae31b02431ac170e9b9e4cabd5d33481d167e801adca3633ad159aeb489395L13-R25): Added new entries for various robot components such as motor controllers and digital inputs.

### Code refactoring:
* [`src/main/java/frc/robot/RobotContainer.java`](diffhunk://#diff-789275cb88dd16cec774f646d9a1711e27f068723fbaa996d4c3c37f9725d525L134-R148): Refactored the `configureAutoBindings` method to use predefined command proxies (`TRY_PREP_CORAL_L3`, `TRY_SCORING_CORAL`, `TRY_NONE`, `TRY_INTAKING_CORAL_HOPPER`).

### Debug message update:
* [`src/main/java/frc/robot/subsystems/StateMachine.java`](diffhunk://#diff-a170d8f5e28be66a41735990530bb2049f36ff92bc4df6338a5af04047830b27L240-R240): Updated the debug message for invalid state handling to "ITS SO OVER D: Invalid State Provided, Blame Eli".