### PR TITLE
123 make prep 0 states

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -293,6 +293,7 @@ public final class Constants {
     public static final Distance ALGAE_L3_CLEANING = Units.Inches.of(35);
     public static final Distance ALGAE_L2_CLEANING = Units.Inches.of(25);
     public static final Distance ALGAE_GROUND_INTAKE = Units.Inches.of(0);
+    public static final Distance PREP_0 = Units.Inches.of(0);
   }
 
   public static class constField {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -108,6 +108,12 @@ public class RobotContainer {
   Command TRY_HAS_ALGAE = Commands.deferredProxy(
       () -> subStateMachine.tryState(RobotState.HAS_ALGAE));
 
+  Command TRY_ALGAE_PREP_0 = Commands.deferredProxy(
+      () -> subStateMachine.tryState(RobotState.ALGAE_PREP_0));
+
+  Command TRY_CORAL_PREP_0 = Commands.deferredProxy(
+      () -> subStateMachine.tryState(RobotState.CORAL_PREP_0));
+
   private final Trigger hasCoralTrigger = new Trigger(subCoralOuttake::hasCoral);
   private final Trigger hasAlgaeTrigger = new Trigger(subAlgaeIntake::hasAlgae);
 
@@ -217,6 +223,12 @@ public class RobotContainer {
     controller.btn_X
         .onTrue(TRY_PREP_CORAL_L4);
 
+    controller.btn_LeftStick
+        .onTrue(TRY_ALGAE_PREP_0);
+
+    controller.btn_RightStick
+        .onTrue(TRY_CORAL_PREP_0);
+
     hasCoralTrigger
         .whileTrue(TRY_HAS_CORAL);
 
@@ -271,17 +283,17 @@ public class RobotContainer {
 
     // btn_A/B/Y/X: Set Elevator to Coral Levels
     controller.btn_A
-    .onTrue(Commands.runOnce(() -> subElevator.setPosition(Constants.constElevator.CORAL_L1_HEIGHT), subElevator));
+        .onTrue(Commands.runOnce(() -> subElevator.setPosition(Constants.constElevator.CORAL_L1_HEIGHT), subElevator));
     controller.btn_B
-    .onTrue(Commands.runOnce(() -> subElevator.setPosition(Constants.constElevator.CORAL_L2_HEIGHT), subElevator));
+        .onTrue(Commands.runOnce(() -> subElevator.setPosition(Constants.constElevator.CORAL_L2_HEIGHT), subElevator));
     controller.btn_Y
-    .onTrue(Commands.runOnce(() -> subElevator.setPosition(Constants.constElevator.CORAL_L3_HEIGHT), subElevator));
+        .onTrue(Commands.runOnce(() -> subElevator.setPosition(Constants.constElevator.CORAL_L3_HEIGHT), subElevator));
     controller.btn_X
-    .onTrue(Commands.runOnce(() -> subElevator.setPosition(Constants.constElevator.CORAL_L4_HEIGHT), subElevator));
+        .onTrue(Commands.runOnce(() -> subElevator.setPosition(Constants.constElevator.CORAL_L4_HEIGHT), subElevator));
   }
-  
+
   SendableChooser<Command> autoChooser = new SendableChooser<>();
-  
+
   public Command getAutonomousCommand() {
     return autoChooser.getSelected();
   }

--- a/src/main/java/frc/robot/commands/states/AlgaePrep0.java
+++ b/src/main/java/frc/robot/commands/states/AlgaePrep0.java
@@ -1,0 +1,50 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.states;
+
+import java.lang.Thread.State;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants;
+import frc.robot.subsystems.Elevator;
+import frc.robot.subsystems.StateMachine;
+
+/* You should consider using the more terse Command factories API instead https://docs.wpilib.org/en/stable/docs/software/commandbased/organizing-command-based.html#defining-commands */
+public class AlgaePrep0 extends Command {
+  /** Creates a new AlgaePrep0. */
+  StateMachine globalStateMachine;
+  Elevator globalElevator;
+
+  public AlgaePrep0(StateMachine subStateMachine, Elevator subElevator) {
+    // Use addRequirements() here to declare subsystem dependencies.
+    globalStateMachine = subStateMachine;
+    globalElevator = subElevator;
+
+    addRequirements(globalStateMachine);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    globalStateMachine.setRobotState(StateMachine.RobotState.ALGAE_PREP_0);
+    globalElevator.setPosition(Constants.constElevator.PREP_0);
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/states/CoralPrep0.java
+++ b/src/main/java/frc/robot/commands/states/CoralPrep0.java
@@ -1,0 +1,50 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.states;
+
+import java.lang.Thread.State;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants;
+import frc.robot.subsystems.Elevator;
+import frc.robot.subsystems.StateMachine;
+
+/* You should consider using the more terse Command factories API instead https://docs.wpilib.org/en/stable/docs/software/commandbased/organizing-command-based.html#defining-commands */
+public class CoralPrep0 extends Command {
+  /** Creates a new CoralPrep0. */
+  StateMachine globalStateMachine;
+  Elevator globalElevator;
+
+  public CoralPrep0(StateMachine subStateMachine, Elevator subElevator) {
+    // Use addRequirements() here to declare subsystem dependencies.
+    globalStateMachine = subStateMachine;
+    globalElevator = subElevator;
+
+    addRequirements(globalStateMachine);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    globalStateMachine.setRobotState(StateMachine.RobotState.CORAL_PREP_0);
+    globalElevator.setPosition(Constants.constElevator.PREP_0);
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/StateMachine.java
+++ b/src/main/java/frc/robot/subsystems/StateMachine.java
@@ -14,6 +14,7 @@ import frc.robot.Constants.constElevator;
 import frc.robot.commands.states.CleaningL2Reef;
 import frc.robot.commands.states.CleaningL3Reef;
 import frc.robot.commands.states.Climb;
+import frc.robot.commands.states.CoralPrep0;
 import frc.robot.commands.states.EjectCoral;
 import frc.robot.commands.states.HasAlgae;
 import frc.robot.commands.states.HasCoral;
@@ -155,12 +156,20 @@ public class StateMachine extends SubsystemBase {
         }
         break;
 
+      case CORAL_PREP_0:
+        switch (currentRobotState) {
+          case HAS_CORAL:
+            return new CoralPrep0(subStateMachine, subElevator);
+        }
+        break;
+
       case SCORING_CORAL:
         switch (currentRobotState) {
           case PREP_CORAL_L1:
           case PREP_CORAL_L2:
           case PREP_CORAL_L3:
           case PREP_CORAL_L4:
+          case CORAL_PREP_0:
             return new PlaceCoral(subStateMachine, subCoralOuttake);
         }
         break;
@@ -226,7 +235,15 @@ public class StateMachine extends SubsystemBase {
         switch (currentRobotState) {
           case PREP_NET:
           case PREP_PROCESSOR:
+          case ALGAE_PREP_0:
             return new ScoringAlgae(subStateMachine, subAlgaeIntake);
+        }
+        break;
+
+      case ALGAE_PREP_0:
+        switch (currentRobotState) {
+          case HAS_ALGAE:
+            return new CoralPrep0(subStateMachine, subElevator);
         }
         break;
 
@@ -236,6 +253,7 @@ public class StateMachine extends SubsystemBase {
             return new Climb(subStateMachine, subClimber);
         }
         break;
+
     }
     return Commands.print("ITS SO OVER D: Invalid State Provided (╯‵□′)╯︵┻━┻");
   }
@@ -250,6 +268,7 @@ public class StateMachine extends SubsystemBase {
     PREP_CORAL_L4,
     EJECTING_CORAL,
     SCORING_CORAL,
+    CORAL_PREP_0,
 
     INTAKING_ALGAE_GROUND,
     CLEANING_L2,
@@ -259,6 +278,7 @@ public class StateMachine extends SubsystemBase {
     PREP_PROCESSOR,
     EJECTING_ALGAE,
     SCORING_ALGAE,
+    ALGAE_PREP_0,
 
     CLIMBING_DEEP
   }
@@ -271,6 +291,8 @@ public class StateMachine extends SubsystemBase {
     PREP_CORAL_L4,
     PREP_NET,
     PREP_PROCESSOR,
+    ALGAE_PREP_0,
+    CORAL_PREP_0,
   }
 
   @Override


### PR DESCRIPTION
This pull request introduces new states for handling algae and coral preparation in the robot's state machine. The most important changes include adding new commands, updating the state machine logic, and configuring operator bindings.

### New Commands:
* Added `AlgaePrep0` command to handle the `ALGAE_PREP_0` state. (`src/main/java/frc/robot/commands/states/AlgaePrep0.java`)
* Added `CoralPrep0` command to handle the `CORAL_PREP_0` state. (`src/main/java/frc/robot/commands/states/CoralPrep0.java`)

### State Machine Updates:
* Updated `StateMachine` to include `ALGAE_PREP_0` and `CORAL_PREP_0` states and their transitions. (`src/main/java/frc/robot/subsystems/StateMachine.java`) [[1]](diffhunk://#diff-a170d8f5e28be66a41735990530bb2049f36ff92bc4df6338a5af04047830b27R17) [[2]](diffhunk://#diff-a170d8f5e28be66a41735990530bb2049f36ff92bc4df6338a5af04047830b27R159-R172) [[3]](diffhunk://#diff-a170d8f5e28be66a41735990530bb2049f36ff92bc4df6338a5af04047830b27R238-R256) [[4]](diffhunk://#diff-a170d8f5e28be66a41735990530bb2049f36ff92bc4df6338a5af04047830b27R271) [[5]](diffhunk://#diff-a170d8f5e28be66a41735990530bb2049f36ff92bc4df6338a5af04047830b27R281) [[6]](diffhunk://#diff-a170d8f5e28be66a41735990530bb2049f36ff92bc4df6338a5af04047830b27R294-R295)

### Operator Bindings:
* Configured new operator bindings for `TRY_ALGAE_PREP_0` and `TRY_CORAL_PREP_0` commands. (`src/main/java/frc/robot/RobotContainer.java`) [[1]](diffhunk://#diff-789275cb88dd16cec774f646d9a1711e27f068723fbaa996d4c3c37f9725d525R111-R116) [[2]](diffhunk://#diff-789275cb88dd16cec774f646d9a1711e27f068723fbaa996d4c3c37f9725d525R226-R231)

### Constants:
* Added `PREP_0` constant for elevator positioning. (`src/main/java/frc/robot/Constants.java`)