### PR TITLE
126 create controller bindings

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -178,9 +178,6 @@ public class RobotContainer {
     // TODO: Has Coral Overide Back BTN
     // TODO: Has Algae Overide Meneu BTN
 
-    // TODO: Prep 0 Algae Left Stick BTN
-    // TODO: Prep 0 Coral Right Stick BTN
-
     controller.btn_North
         .onTrue(TRY_PREP_NET);
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -160,16 +160,20 @@ public class RobotContainer {
 
   private void configureOperatorBindings(SN_XboxController controller) {
     controller.btn_LeftTrigger
-        .whileTrue(TRY_INTAKING_CORAL_HOPPER);
+        .whileTrue(TRY_INTAKING_CORAL_HOPPER)
+        .onFalse(TRY_NONE);
 
     controller.btn_RightTrigger
-        .whileTrue(TRY_SCORING_CORAL);
+        .whileTrue(TRY_SCORING_CORAL)
+        .onFalse(TRY_NONE);
 
     controller.btn_LeftBumper
-        .whileTrue(TRY_INTAKING_ALGAE_GROUND);
+        .whileTrue(TRY_INTAKING_ALGAE_GROUND)
+        .onFalse(TRY_NONE);
 
     controller.btn_RightBumper
-        .whileTrue(TRY_SCORING_ALGAE);
+        .whileTrue(TRY_SCORING_ALGAE)
+        .onFalse(TRY_NONE);
 
     // TODO: Has Coral Overide Back BTN
     // TODO: Has Algae Overide Meneu BTN
@@ -181,10 +185,12 @@ public class RobotContainer {
         .onTrue(TRY_PREP_NET);
 
     controller.btn_East
-        .whileTrue(TRY_CLEANING_L3);
+        .whileTrue(TRY_CLEANING_L3)
+        .onFalse(TRY_NONE);
 
     controller.btn_West
-        .whileTrue(TRY_CLEANING_L2);
+        .whileTrue(TRY_CLEANING_L2)
+        .onFalse(TRY_NONE);
 
     controller.btn_South
         .whileTrue(TRY_PREP_PROCESSOR);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -149,73 +149,58 @@ public class RobotContainer {
   }
 
   private void configureDriverBindings(SN_XboxController controller) {
-    controller.btn_B.onTrue(Commands.runOnce(() -> subDrivetrain.resetModulesToAbsolute()));
-    controller.btn_Back
-        .onTrue(Commands.runOnce(() -> subDrivetrain.resetPoseToPose(constField.getFieldPositions().get()[0])));
+    controller.btn_B
+        .onTrue(TRY_CLIMBING_DEEP);
+
+    // TODO: Add Teleop Align to LT and RT
+
+    controller.btn_North
+        .onTrue(Commands.runOnce(() -> subDrivetrain.resetModulesToAbsolute()));
   }
 
   private void configureOperatorBindings(SN_XboxController controller) {
-
-    // Start: Reset Elevator Sensor Position
-    controller.btn_Start.onTrue(Commands.runOnce(() -> subElevator.resetSensorPosition(Units.Inches.of(0)))
-        .ignoringDisable(true));
-
-    controller.btn_Back
-        .whileTrue(TRY_INTAKING_CORAL_HOPPER)
-        .onFalse(TRY_NONE);
-
     controller.btn_LeftTrigger
-        .whileTrue(TRY_INTAKING_ALGAE_GROUND)
-        .onFalse(TRY_NONE);
+        .whileTrue(TRY_INTAKING_CORAL_HOPPER);
 
     controller.btn_RightTrigger
-        .onTrue(TRY_SCORING_ALGAE)
-        .onFalse(TRY_NONE);
-
-    controller.btn_RightBumper
-        .whileTrue(TRY_SCORING_CORAL)
-        .onFalse(TRY_NONE);
+        .whileTrue(TRY_SCORING_CORAL);
 
     controller.btn_LeftBumper
-        .whileTrue(TRY_CLIMBING_DEEP)
-        .onFalse(TRY_NONE);
+        .whileTrue(TRY_INTAKING_ALGAE_GROUND);
 
-    controller.btn_East
-        .onTrue(Commands.runOnce(() -> subElevator.setNeutral(), subElevator));
+    controller.btn_RightBumper
+        .whileTrue(TRY_SCORING_ALGAE);
 
-    controller.btn_South
-        .onTrue(TRY_PREP_PROCESSOR);
+    // TODO: Has Coral Overide Back BTN
+    // TODO: Has Algae Overide Meneu BTN
 
-    controller.btn_West
-        .whileTrue(TRY_CLEANING_L3)
-        .onFalse(TRY_NONE);
+    // TODO: Prep 0 Algae Left Stick BTN
+    // TODO: Prep 0 Coral Right Stick BTN
 
     controller.btn_North
-        .whileTrue(TRY_CLEANING_L2)
-        .onFalse(TRY_NONE);
-
-    controller.btn_NorthWest
         .onTrue(TRY_PREP_NET);
 
-    // btn_SouthEast: Eject Algae
-    controller.btn_SouthEast
-        .whileTrue(TRY_EJECTING_ALGAE)
-        .onFalse(TRY_NONE);
+    controller.btn_East
+        .whileTrue(TRY_CLEANING_L3);
+
+    controller.btn_West
+        .whileTrue(TRY_CLEANING_L2);
+
+    controller.btn_South
+        .whileTrue(TRY_PREP_PROCESSOR);
 
     controller.btn_A
         .onTrue(TRY_PREP_CORAL_L1);
+
     controller.btn_B
-        .onTrue(TRY_PREP_CORAL_L2);
-    controller.btn_Y
         .onTrue(TRY_PREP_CORAL_L3);
+
     controller.btn_X
+        .onTrue(TRY_PREP_CORAL_L2);
+
+    controller.btn_Y
         .onTrue(TRY_PREP_CORAL_L4);
 
-    hasCoralTrigger
-        .whileTrue(TRY_HAS_CORAL);
-
-    hasAlgaeTrigger
-        .whileTrue(TRY_HAS_ALGAE);
   }
 
   private void configureTesterBindings(SN_XboxController controller) {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -152,8 +152,6 @@ public class RobotContainer {
     controller.btn_B
         .onTrue(TRY_CLIMBING_DEEP);
 
-    // TODO: Add Teleop Align to LT and RT
-
     controller.btn_North
         .onTrue(Commands.runOnce(() -> subDrivetrain.resetModulesToAbsolute()));
   }


### PR DESCRIPTION
This pull request includes significant changes to the `RobotContainer` class, specifically within the `configureDriverBindings` and `configureOperatorBindings` methods. The changes primarily involve reassigning button actions for the Xbox controller used to control the robot.

Reassignments and additions to button actions:

* `configureDriverBindings` method: The `btn_B` button now triggers `TRY_CLIMBING_DEEP` instead of resetting the drivetrain modules to absolute positions. The `btn_North` button now resets the drivetrain modules to absolute positions.
* `configureOperatorBindings` method: Several buttons have been reassigned to different actions, including `btn_LeftTrigger`, `btn_RightTrigger`, `btn_LeftBumper`, `btn_RightBumper`, `btn_North`, `btn_East`, `btn_West`, `btn_South`, `btn_A`, `btn_B`, `btn_X`, and `btn_Y`. Additionally, several TODO comments have been added for future functionality.