### PR TITLE
Updated to Using * Imports

### DIFF
--- a/src/main/java/frc/robot/subsystems/StateMachine.java
+++ b/src/main/java/frc/robot/subsystems/StateMachine.java
@@ -7,25 +7,9 @@ package frc.robot.subsystems;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.NotLogged;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Commands;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.constElevator;
-import frc.robot.commands.states.CleaningL2Reef;
-import frc.robot.commands.states.CleaningL3Reef;
-import frc.robot.commands.states.Climb;
-import frc.robot.commands.states.PrepCoralZero;
-import frc.robot.commands.states.EjectCoral;
-import frc.robot.commands.states.HasAlgae;
-import frc.robot.commands.states.HasCoral;
-import frc.robot.commands.states.IntakeCoralHopper;
-import frc.robot.commands.states.IntakingAlgaeGround;
-import frc.robot.commands.states.None;
-import frc.robot.commands.states.PlaceCoral;
-import frc.robot.commands.states.PrepCoralLv;
-import frc.robot.commands.states.PrepNet;
-import frc.robot.commands.states.PrepProcessor;
-import frc.robot.commands.states.ScoringAlgae;
+import edu.wpi.first.wpilibj2.command.*;
+import frc.robot.commands.states.*;
 
 @Logged
 public class StateMachine extends SubsystemBase {


### PR DESCRIPTION
This pull request includes changes to the `StateMachine.java` file to simplify and clean up the import statements. The most important change is the consolidation of multiple individual imports into grouped imports.

Codebase simplification:

* [`src/main/java/frc/robot/subsystems/StateMachine.java`](diffhunk://#diff-a170d8f5e28be66a41735990530bb2049f36ff92bc4df6338a5af04047830b27L10-R12): Consolidated multiple individual imports from `edu.wpi.first.wpilibj2.command` and `frc.robot.commands.states` into grouped imports. This reduces redundancy and improves readability.