### PR TITLE
create RobotPoses subsystem

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -43,7 +43,6 @@ public class Robot extends TimedRobot {
   @Override
   public void robotPeriodic() {
     m_robotContainer.AddVisionMeasurement().schedule();
-    m_robotContainer.updateLoggedPoses();
     CommandScheduler.getInstance().run();
   }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -11,10 +11,6 @@ import com.pathplanner.lib.commands.PathPlannerAuto;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.wpilibj.DigitalInput;
-import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.math.geometry.Rotation3d;
-import edu.wpi.first.math.geometry.Transform3d;
-import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -125,10 +121,6 @@ public class RobotContainer {
 
   private final Trigger hasCoralTrigger = new Trigger(subCoralOuttake::hasCoral);
   private final Trigger hasAlgaeTrigger = new Trigger(subAlgaeIntake::hasAlgae);
-
-  private Pose3d elevatorStageOne = Pose3d.kZero;
-  private Pose3d elevatorCarriage = Pose3d.kZero;
-  private Pose3d algaeIntake = Pose3d.kZero;
 
   public RobotContainer() {
     conDriver.setLeftDeadband(constControllers.DRIVER_LEFT_STICK_DEADBAND);
@@ -343,32 +335,5 @@ public class RobotContainer {
    */
   public static boolean isPracticeBot() {
     return !isPracticeBot.get();
-  }
-
-  public void updateLoggedPoses() {
-    double elevatorPos, algaeAngle;
-
-    // If we're in simulation, we can't log real mechanism data because they don't
-    // exist. Instead, we'll log where we *want* the mechanisms to be and assume
-    // they get there instantly.
-    if (Robot.isSimulation()) {
-      elevatorPos = subElevator.getLastDesiredPosition().in(Units.Meters) / 2;
-      algaeAngle = subAlgaeIntake.getLastDesiredPivotAngle().in(Units.Degrees);
-    } else {
-      // Use real positions
-      elevatorPos = (subElevator.getElevatorPosition().in(Units.Meters) / 2);
-      algaeAngle = subAlgaeIntake.getPivotAngle().in(Units.Degrees);
-    }
-
-    elevatorStageOne = new Pose3d(new Translation3d(0.0889,
-        0,
-        0.109474 + elevatorPos), Rotation3d.kZero);
-
-    elevatorCarriage = elevatorStageOne
-        .transformBy(new Transform3d(new Translation3d(0, 0, Units.Inches.of(1).in(Units.Meters) + elevatorPos),
-            Rotation3d.kZero));
-
-    algaeIntake = elevatorCarriage
-        .transformBy(new Transform3d(new Translation3d(0.075438, 0, 0.292354), new Rotation3d(0, algaeAngle, 0)));
   }
 }

--- a/src/main/java/frc/robot/subsystems/RobotPoses.java
+++ b/src/main/java/frc/robot/subsystems/RobotPoses.java
@@ -1,0 +1,57 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems;
+
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.units.Units;
+import frc.robot.Robot;
+
+public class RobotPoses extends SubsystemBase {
+
+  Pose3d elevatorStageOne = Pose3d.kZero;
+  Pose3d elevatorCarriage = Pose3d.kZero;
+  Pose3d algaeIntake = Pose3d.kZero;
+  private final Elevator subElevator = new Elevator();
+  private final AlgaeIntake subAlgaeIntake = new AlgaeIntake();
+
+  /** Creates a new RobotPoses. */
+  public RobotPoses() {
+  }
+
+  @Override
+  public void periodic() {
+    // This method will be called once per scheduler run
+
+    double elevatorPos, algaeAngle;
+
+    // If we're in simulation, we can't log real mechanism data because they don't
+    // exist. Instead, we'll log where we *want* the mechanisms to be and assume
+    // they get there instantly.
+    if (Robot.isSimulation()) {
+      elevatorPos = subElevator.getLastDesiredPosition().in(Units.Meters) / 2;
+      algaeAngle = subAlgaeIntake.getLastDesiredPivotAngle().in(Units.Degrees);
+    } else {
+      // Use real positions
+      elevatorPos = (subElevator.getElevatorPosition().in(Units.Meters) / 2);
+      algaeAngle = subAlgaeIntake.getPivotAngle().in(Units.Degrees);
+    }
+
+    elevatorStageOne = new Pose3d(new Translation3d(0.0889,
+        0,
+        0.109474 + elevatorPos), Rotation3d.kZero);
+
+    elevatorCarriage = elevatorStageOne
+        .transformBy(new Transform3d(new Translation3d(0, 0, Units.Inches.of(1).in(Units.Meters) + elevatorPos),
+            Rotation3d.kZero));
+
+    algaeIntake = elevatorCarriage
+        .transformBy(new Transform3d(new Translation3d(0.075438, 0, 0.292354), new Rotation3d(0, algaeAngle, 0)));
+
+  }
+}


### PR DESCRIPTION
This pull request includes significant changes to the `RobotContainer` class and introduces a new `RobotPoses` subsystem. The most important changes include the removal of pose-related methods and fields from `RobotContainer` and their relocation to the new `RobotPoses` subsystem.

### Codebase restructuring:

* [`src/main/java/frc/robot/RobotContainer.java`](diffhunk://#diff-789275cb88dd16cec774f646d9a1711e27f068723fbaa996d4c3c37f9725d525L14-L17): Removed pose-related imports and fields, including `Pose3d` instances for `elevatorStageOne`, `elevatorCarriage`, and `algaeIntake`. Also removed the `updateLoggedPoses` method. [[1]](diffhunk://#diff-789275cb88dd16cec774f646d9a1711e27f068723fbaa996d4c3c37f9725d525L14-L17) [[2]](diffhunk://#diff-789275cb88dd16cec774f646d9a1711e27f068723fbaa996d4c3c37f9725d525L129-L132) [[3]](diffhunk://#diff-789275cb88dd16cec774f646d9a1711e27f068723fbaa996d4c3c37f9725d525L347-L373)

* [`src/main/java/frc/robot/subsystems/RobotPoses.java`](diffhunk://#diff-446c05a5c0362cc986d81002106aae6f3039a6f5534a06fd85f48f301bf60affR1-R57): Added a new `RobotPoses` subsystem to handle pose updates for the elevator and algae intake. This includes the `periodic` method to log the positions based on whether the robot is in simulation or not.

### Minor changes:

* [`src/main/java/frc/robot/Robot.java`](diffhunk://#diff-3785d4501710483be1c16f09c87e5a6c768ae9c2cba1a8173b2c227b65047db0L46): Removed the call to `m_robotContainer.updateLoggedPoses()` in the `robotPeriodic` method.