### PR TITLE
Refactor IntakeCoralHopper to use global variable naming for subsystems

### DIFF
--- a/src/main/java/frc/robot/commands/states/IntakeCoralHopper.java
+++ b/src/main/java/frc/robot/commands/states/IntakeCoralHopper.java
@@ -7,17 +7,13 @@ package frc.robot.commands.states;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants;
 import frc.robot.Constants.constLED;
-import frc.robot.subsystems.CoralOuttake;
-import frc.robot.subsystems.Elevator;
-import frc.robot.subsystems.Hopper;
-import frc.robot.subsystems.LED;
-import frc.robot.subsystems.StateMachine;
+import frc.robot.subsystems.*;
 
 /* You should consider using the more terse Command factories API instead https://docs.wpilib.org/en/stable/docs/software/commandbased/organizing-command-based.html#defining-commands */
 public class IntakeCoralHopper extends Command {
   StateMachine globalStateMachine;
-  Hopper subCoralIntake;
-  CoralOuttake subCoralOuttake;
+  Hopper globalCoralIntake;
+  CoralOuttake globalCoralOuttake;
   Elevator globalElevator;
   LED globalLED;
 
@@ -26,8 +22,8 @@ public class IntakeCoralHopper extends Command {
       LED subLED, Elevator subElevator) {
     // Use addRequirements() here to declare subsystem dependencies.
     globalStateMachine = subStateMachine;
-    this.subCoralIntake = subHopper;
-    this.subCoralOuttake = subCoralOuttake;
+    this.globalCoralIntake = subHopper;
+    this.globalCoralOuttake = subCoralOuttake;
     globalLED = subLED;
     globalElevator = subElevator;
     addRequirements(globalStateMachine);
@@ -37,8 +33,8 @@ public class IntakeCoralHopper extends Command {
   @Override
   public void initialize() {
     globalStateMachine.setRobotState(StateMachine.RobotState.INTAKING_CORAL_HOPPER);
-    subCoralOuttake.setCoralOuttake(Constants.constCoralOuttake.CORAL_INTAKE_SPEED);
-    subCoralIntake.runHopper(Constants.constHopper.HOPPER_SPEED);
+    globalCoralOuttake.setCoralOuttake(Constants.constCoralOuttake.CORAL_INTAKE_SPEED);
+    globalCoralIntake.runHopper(Constants.constHopper.HOPPER_SPEED);
     globalLED.setLED(constLED.LED_INTAKE_CORAL_HOPPER);
     globalElevator.setPosition(Constants.constElevator.CORAL_INTAKE_HIGHT);
   }
@@ -51,13 +47,13 @@ public class IntakeCoralHopper extends Command {
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
-    subCoralOuttake.setCoralOuttake(0);
-    subCoralIntake.runHopper(0);
+    globalCoralOuttake.setCoralOuttake(0);
+    globalCoralIntake.runHopper(0);
   }
 
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return subCoralOuttake.hasCoral();
+    return globalCoralOuttake.hasCoral();
   }
 }

--- a/src/main/java/frc/robot/commands/states/IntakeCoralHopper.java
+++ b/src/main/java/frc/robot/commands/states/IntakeCoralHopper.java
@@ -12,7 +12,7 @@ import frc.robot.subsystems.*;
 /* You should consider using the more terse Command factories API instead https://docs.wpilib.org/en/stable/docs/software/commandbased/organizing-command-based.html#defining-commands */
 public class IntakeCoralHopper extends Command {
   StateMachine globalStateMachine;
-  Hopper globalCoralIntake;
+  Hopper globalHopper;
   CoralOuttake globalCoralOuttake;
   Elevator globalElevator;
   LED globalLED;
@@ -22,7 +22,7 @@ public class IntakeCoralHopper extends Command {
       LED subLED, Elevator subElevator) {
     // Use addRequirements() here to declare subsystem dependencies.
     globalStateMachine = subStateMachine;
-    this.globalCoralIntake = subHopper;
+    this.globalHopper = subHopper;
     this.globalCoralOuttake = subCoralOuttake;
     globalLED = subLED;
     globalElevator = subElevator;
@@ -34,7 +34,7 @@ public class IntakeCoralHopper extends Command {
   public void initialize() {
     globalStateMachine.setRobotState(StateMachine.RobotState.INTAKING_CORAL_HOPPER);
     globalCoralOuttake.setCoralOuttake(Constants.constCoralOuttake.CORAL_INTAKE_SPEED);
-    globalCoralIntake.runHopper(Constants.constHopper.HOPPER_SPEED);
+    globalHopper.runHopper(Constants.constHopper.HOPPER_SPEED);
     globalLED.setLED(constLED.LED_INTAKE_CORAL_HOPPER);
     globalElevator.setPosition(Constants.constElevator.CORAL_INTAKE_HIGHT);
   }
@@ -48,7 +48,7 @@ public class IntakeCoralHopper extends Command {
   @Override
   public void end(boolean interrupted) {
     globalCoralOuttake.setCoralOuttake(0);
-    globalCoralIntake.runHopper(0);
+    globalHopper.runHopper(0);
   }
 
   // Returns true when the command should end.


### PR DESCRIPTION
This pull request includes changes to the `IntakeCoralHopper` command in the `src/main/java/frc/robot/commands/states/IntakeCoralHopper.java` file. The primary focus is on refactoring variable names for consistency and clarity.

Refactoring for consistency and clarity:

* Changed imports to use wildcard for subsystems. (`src/main/java/frc/robot/commands/states/IntakeCoralHopper.java`)
* Renamed `subCoralIntake` to `globalCoralIntake` and `subCoralOuttake` to `globalCoralOuttake` throughout the file. (`src/main/java/frc/robot/commands/states/IntakeCoralHopper.java`) [[1]](diffhunk://#diff-0fb101d512cb643b49d35f8acdbdd4fb25435567623443d2c75eede592a519efL29-R26) [[2]](diffhunk://#diff-0fb101d512cb643b49d35f8acdbdd4fb25435567623443d2c75eede592a519efL40-R37) [[3]](diffhunk://#diff-0fb101d512cb643b49d35f8acdbdd4fb25435567623443d2c75eede592a519efL54-R57)