### PR TITLE
Removed Second Climber Motor ᕙ(⊙‸⊙)ᕗ

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -45,7 +45,6 @@ import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.units.measure.Mass;
 import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.units.measure.Voltage;
-import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -38,7 +38,6 @@ public class RobotMap {
 
   public static class mapClimber {
     public static final int CLIMBER_LEFT_CAN = 20;
-    public static final int CLIMBER_RIGHT_CAN = 21;
   }
 
   public static class mapAlgaeIntake {

--- a/src/main/java/frc/robot/commands/Zeroing/ManualZeroElevator.java
+++ b/src/main/java/frc/robot/commands/Zeroing/ManualZeroElevator.java
@@ -4,11 +4,8 @@
 
 package frc.robot.commands.Zeroing;
 
-import edu.wpi.first.units.DistanceUnit;
-import edu.wpi.first.units.Measure;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.units.measure.AngularVelocity;
-import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -6,7 +6,6 @@ package frc.robot.subsystems;
 
 import static edu.wpi.first.units.Units.Rotations;
 
-import com.ctre.phoenix6.controls.Follower;
 import com.ctre.phoenix6.controls.NeutralOut;
 import com.ctre.phoenix6.controls.PositionVoltage;
 import com.ctre.phoenix6.hardware.TalonFX;

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -23,20 +23,17 @@ import frc.robot.Constants.constClimber;
 public class Climber extends SubsystemBase {
   /** Creates a new Climber. */
   TalonFX climberMotor;
-  TalonFX climberMotor2;
   Angle lastDesiredPosition;
 
   public Climber() {
     lastDesiredPosition = Units.Degrees.of(0);
     climberMotor = new TalonFX(RobotMap.mapClimber.CLIMBER_LEFT_CAN);
-    climberMotor2 = new TalonFX(RobotMap.mapClimber.CLIMBER_RIGHT_CAN);
 
     climberMotor.getConfigurator().apply(constClimber.CLIMBER_CONFIG);
   }
 
   public void setClimberMotorVelocity(double velocity) {
     climberMotor.set(velocity);
-    climberMotor2.set(-velocity);
   }
 
   public Distance getClimberPosition() {
@@ -45,18 +42,15 @@ public class Climber extends SubsystemBase {
 
   public void setPosition(Angle angle) {
     climberMotor.setControl(new PositionVoltage(angle.in(Units.Rotations)));
-    climberMotor2.setControl(new Follower(climberMotor.getDeviceID(), true));
     lastDesiredPosition = angle;
   }
 
   public void setNeutral() {
     climberMotor.setControl(new NeutralOut());
-    climberMotor2.setControl(new NeutralOut());
   }
 
   public void resetSensorPosition(Angle setpoint) {
     climberMotor.setPosition(setpoint.in(Rotations));
-    climberMotor2.setPosition(setpoint.in(Rotations));
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import com.frcteam3255.components.swerve.SN_SuperSwerve;
 import com.frcteam3255.components.swerve.SN_SwerveModule;
-import com.frcteam3255.utils.SN_Math;
 
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.math.MathUtil;

--- a/src/main/java/frc/robot/subsystems/RobotPoses.java
+++ b/src/main/java/frc/robot/subsystems/RobotPoses.java
@@ -16,7 +16,6 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Distance;
 import frc.robot.Robot;
 import frc.robot.Constants.constAlgaeIntake;
-import frc.robot.Constants.constCoralOuttake;
 import frc.robot.Constants.constElevator;
 import frc.robot.Constants.constField;
 


### PR DESCRIPTION
This pull request includes several changes aimed at cleaning up the codebase by removing unused imports and redundant code, as well as simplifying the `Climber` subsystem. The most important changes include the removal of unused imports across multiple files and the refactoring of the `Climber` subsystem to use a single motor instead of two.

Code cleanup:

* [`src/main/java/frc/robot/Constants.java`](diffhunk://#diff-ea1fc0a250d9f1ec245395d6ededa6e0eeec69c1ffaa359273a1bafddd557811L48): Removed unused import `edu.wpi.first.units.Measure`.
* [`src/main/java/frc/robot/commands/Zeroing/ManualZeroElevator.java`](diffhunk://#diff-ee630c559cf859a6a23d71f90236493d16ce79eeac9449260308afc9813b181aL7-L11): Removed unused imports `edu.wpi.first.units.DistanceUnit`, `edu.wpi.first.units.Measure`, and `edu.wpi.first.units.measure.Distance`.
* [`src/main/java/frc/robot/subsystems/Drivetrain.java`](diffhunk://#diff-7d050cdb8575fee506434435cd638407d740d181d541be3bab6e3135bcd17908L14): Removed unused import `com.frcteam3255.utils.SN_Math`.
* [`src/main/java/frc/robot/subsystems/RobotPoses.java`](diffhunk://#diff-446c05a5c0362cc986d81002106aae6f3039a6f5534a06fd85f48f301bf60affL19): Removed unused import `frc.robot.Constants.constCoralOuttake`.

Refactoring `Climber` subsystem:

* [`src/main/java/frc/robot/subsystems/Climber.java`](diffhunk://#diff-1000d31648c1ff8b42b5deec3bee8047af990c42a3ff199d5ed9423a8046aaf3L26-L39): Removed the second climber motor (`climberMotor2`) and all related code, simplifying the subsystem to use only `climberMotor`. [[1]](diffhunk://#diff-1000d31648c1ff8b42b5deec3bee8047af990c42a3ff199d5ed9423a8046aaf3L26-L39) [[2]](diffhunk://#diff-1000d31648c1ff8b42b5deec3bee8047af990c42a3ff199d5ed9423a8046aaf3L48-L59)