### PR TITLE
Added Driver Camera to Teleop Tab ヽ(ﾟДﾟ)ﾉ

### DIFF
--- a/src/main/deploy/elastic-layout.json
+++ b/src/main/deploy/elastic-layout.json
@@ -11,7 +11,7 @@
             "title": "Driving State",
             "x": 0.0,
             "y": 102.0,
-            "width": 680.0,
+            "width": 374.0,
             "height": 102.0,
             "type": "Large Text Display",
             "properties": {
@@ -22,9 +22,9 @@
           },
           {
             "title": "Robot State",
-            "x": 680.0,
+            "x": 952.0,
             "y": 102.0,
-            "width": 680.0,
+            "width": 408.0,
             "height": 102.0,
             "type": "Large Text Display",
             "properties": {
@@ -95,10 +95,10 @@
           },
           {
             "title": "All At Set Point",
-            "x": 680.0,
-            "y": 204.0,
-            "width": 272.0,
-            "height": 238.0,
+            "x": 816.0,
+            "y": 102.0,
+            "width": 136.0,
+            "height": 340.0,
             "type": "Boolean Box",
             "properties": {
               "topic": "Robot/m_robotContainer/elevatorAndAlgaeAtSetPoint",
@@ -113,9 +113,9 @@
           {
             "title": "Is Aligned",
             "x": 374.0,
-            "y": 204.0,
-            "width": 306.0,
-            "height": 238.0,
+            "y": 102.0,
+            "width": 136.0,
+            "height": 340.0,
             "type": "Boolean Box",
             "properties": {
               "topic": "Robot/m_robotContainer/isAligned",
@@ -141,6 +141,21 @@
               "time_display_mode": "Minutes and Seconds",
               "red_start_time": 15,
               "yellow_start_time": 30
+            }
+          },
+          {
+            "title": "Climber Camera",
+            "x": 510.0,
+            "y": 102.0,
+            "width": 306.0,
+            "height": 340.0,
+            "type": "Camera Stream",
+            "properties": {
+              "topic": "/CameraPublisher/USB Camera 0",
+              "period": 0.06,
+              "rotation_turns": 0,
+              "compression": 40,
+              "fps": 30
             }
           }
         ]


### PR DESCRIPTION
This pull request includes several changes to the `elastic-layout.json` file to adjust the layout and add a new camera stream. The most important changes include resizing and repositioning existing elements and adding a new "Climber Camera" element.

Layout adjustments:

* Resized the "Driving State" element from a width of 680.0 to 374.0.
* Repositioned and resized the "Robot State" element, changing its x-coordinate from 680.0 to 952.0 and its width from 680.0 to 408.0.
* Repositioned and resized the "All At Set Point" element, changing its x-coordinate from 680.0 to 816.0, y-coordinate from 204.0 to 102.0, width from 272.0 to 136.0, and height from 238.0 to 340.0.
* Repositioned and resized the "Is Aligned" element, changing its y-coordinate from 204.0 to 102.0, width from 306.0 to 136.0, and height from 238.0 to 340.0.

New element addition:

* Added a new "Climber Camera" element with a width of 306.0, height of 340.0, and properties for camera stream settings.