### PR TITLE
Create climb auto align on the opposing side (。・・)ノ

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -675,8 +675,10 @@ public final class Constants {
       public static final Pose2d CAGE_2 = new Pose2d(7.783, 6.151, Rotation2d.fromDegrees(180));
       public static final Pose2d CAGE_3 = new Pose2d(7.783, 5.068, Rotation2d.fromDegrees(180));
 
-      private static final List<Pose2d> BLUE_CAGE_POSES = List.of(CAGE_1, CAGE_2, CAGE_3);
-      private static final List<Pose2d> RED_CAGE_POSES = getRedCagePoses();
+      private static final List<Pose2d> OUR_SIDE_BLUE_CAGE_POSES = List.of(CAGE_1, CAGE_2, CAGE_3);
+      private static final List<Pose2d> OUR_SIDE_RED_CAGE_POSES = getRedCagePoses();
+      private static final List<Pose2d> OPPOSING_SIDE_BLUE_CAGE_POSES = getOpposingSideBlueCagePoses();
+      private static final List<Pose2d> OPPOSING_SIDE_RED_CAGE_POSES = getOpposingSideRedCagePoses();
 
       private static final Pose2d[] BLUE_POSES = new Pose2d[] { RESET_POSE, REEF_A, REEF_B, REEF_C, REEF_D, REEF_E,
           REEF_F, REEF_G, REEF_H, REEF_I, REEF_J, REEF_K, REEF_L, REEF_CENTER, REEF_A_CLOSE, REEF_B_CLOSE, REEF_C_CLOSE,
@@ -707,6 +709,11 @@ public final class Constants {
         returnedPoses[i] = getRedAlliancePose(bluePoseList.get(i));
       }
       return returnedPoses;
+    }
+
+    public static Pose2d getOpposingSideCagePoses(Pose2d poses) {
+      return new Pose2d(FIELD_LENGTH.in(Units.Meters) - (poses.getX()), poses.getY(),
+          poses.getRotation().plus(Rotation2d.k180deg));
     }
 
     private static List<Pose2d> getRedReefPoses() {
@@ -740,10 +747,30 @@ public final class Constants {
     }
 
     private static List<Pose2d> getRedCagePoses() {
-      Pose2d[] returnedPoses = new Pose2d[POSES.BLUE_CAGE_POSES.size()];
+      Pose2d[] returnedPoses = new Pose2d[POSES.OUR_SIDE_BLUE_CAGE_POSES.size()];
 
-      for (int i = 0; i < POSES.BLUE_CAGE_POSES.size(); i++) {
-        returnedPoses[i] = getRedAlliancePose(POSES.BLUE_CAGE_POSES.get(i));
+      for (int i = 0; i < POSES.OUR_SIDE_BLUE_CAGE_POSES.size(); i++) {
+        returnedPoses[i] = getRedAlliancePose(POSES.OUR_SIDE_BLUE_CAGE_POSES.get(i));
+      }
+
+      return List.of(returnedPoses[0], returnedPoses[1], returnedPoses[2]);
+    }
+
+    private static List<Pose2d> getOpposingSideBlueCagePoses() {
+      Pose2d[] returnedPoses = new Pose2d[POSES.OUR_SIDE_BLUE_CAGE_POSES.size()];
+
+      for (int i = 0; i < POSES.OUR_SIDE_BLUE_CAGE_POSES.size(); i++) {
+        returnedPoses[i] = getOpposingSideCagePoses(POSES.OUR_SIDE_BLUE_CAGE_POSES.get(i));
+      }
+
+      return List.of(returnedPoses[0], returnedPoses[1], returnedPoses[2]);
+    }
+
+    private static List<Pose2d> getOpposingSideRedCagePoses() {
+      Pose2d[] returnedPoses = new Pose2d[POSES.OUR_SIDE_RED_CAGE_POSES.size()];
+
+      for (int i = 0; i < POSES.OUR_SIDE_RED_CAGE_POSES.size(); i++) {
+        returnedPoses[i] = getOpposingSideCagePoses(POSES.OUR_SIDE_RED_CAGE_POSES.get(i));
       }
 
       return List.of(returnedPoses[0], returnedPoses[1], returnedPoses[2]);
@@ -820,12 +847,27 @@ public final class Constants {
       return () -> POSES.BLUE_ALGAE_POSES;
     }
 
-    public static Supplier<List<Pose2d>> getCagePositions() {
-      if (ALLIANCE.isPresent() && ALLIANCE.get().equals(Alliance.Red)) {
-        return () -> POSES.RED_CAGE_POSES;
+    public static Supplier<List<Pose2d>> getBlueCagePositions(boolean onOpposingSide) {
+      if (onOpposingSide) {
+        return () -> POSES.OPPOSING_SIDE_BLUE_CAGE_POSES;
 
       }
-      return () -> POSES.BLUE_CAGE_POSES;
+      return () -> POSES.OUR_SIDE_BLUE_CAGE_POSES;
+    }
+
+    public static Supplier<List<Pose2d>> getRedCagePositions(boolean onOpposingSide) {
+      if (onOpposingSide) {
+        return () -> POSES.OPPOSING_SIDE_RED_CAGE_POSES;
+
+      }
+      return () -> POSES.OUR_SIDE_RED_CAGE_POSES;
+    }
+
+    public static Supplier<List<Pose2d>> getAllCagePositions(boolean onOpposingSide) {
+      if (ALLIANCE.isPresent() && ALLIANCE.get().equals(Alliance.Red)) {
+        return () -> getRedCagePositions(onOpposingSide).get();
+      }
+      return () -> getBlueCagePositions(onOpposingSide).get();
     }
   }
 

--- a/src/main/java/frc/robot/commands/DriveManual.java
+++ b/src/main/java/frc/robot/commands/DriveManual.java
@@ -220,12 +220,13 @@ public class DriveManual extends Command {
     else if (prepClimbValid) {
       netAlignStarted = false;
       processorAlignStarted = false;
+      boolean onOpposingSide = subDrivetrain.getPose().getX() > 8.775;
 
       if (Math.abs(rotationAxis.getAsDouble()) > 0.0) {
         prepClimbValid = false;
       }
 
-      List<Pose2d> cagePoses = constField.getCagePositions().get();
+      List<Pose2d> cagePoses = constField.getAllCagePositions(onOpposingSide).get();
       Pose2d desiredCage = currentPose.nearest(cagePoses);
 
       subDrivetrain.rotationalAlign(desiredCage, xVelocity, yVelocity, isOpenLoop,

--- a/src/main/java/frc/robot/commands/DriveManual.java
+++ b/src/main/java/frc/robot/commands/DriveManual.java
@@ -38,7 +38,7 @@ public class DriveManual extends Command {
   double slowMultiplier = 0;
   Pose2d netPose, desiredNetPose;
   boolean netAlignStarted = false;
-  Pose2d processorPose, desiredProcessorPose;
+  Pose2d processorPose, desiredProcessorPose, desiredCage = new Pose2d();
   boolean processorAlignStarted = false;
   boolean prepClimbValid = false;
 
@@ -118,6 +118,9 @@ public class DriveManual extends Command {
 
     if (prepClimb.getAsBoolean()) {
       prepClimbValid = true;
+      boolean onOpposingSide = subDrivetrain.getPose().getX() > 8.775;
+      List<Pose2d> cagePoses = constField.getAllCagePositions(onOpposingSide).get();
+      desiredCage = currentPose.nearest(cagePoses);
     }
 
     // -- Controlling --
@@ -220,15 +223,10 @@ public class DriveManual extends Command {
     else if (prepClimbValid) {
       netAlignStarted = false;
       processorAlignStarted = false;
-      boolean onOpposingSide = subDrivetrain.getPose().getX() > 8.775;
 
       if (Math.abs(rotationAxis.getAsDouble()) > constControllers.DRIVER_LEFT_STICK_DEADBAND) {
         prepClimbValid = false;
       }
-
-      List<Pose2d> cagePoses = constField.getAllCagePositions(onOpposingSide).get();
-      Pose2d desiredCage = currentPose.nearest(cagePoses);
-
       subDrivetrain.rotationalAlign(desiredCage, xVelocity, yVelocity, isOpenLoop,
           DriverState.CAGE_ROTATION_SNAPPING, subStateMachine);
     }


### PR DESCRIPTION
This pull request includes changes to the `src/main/java/frc/robot/Constants.java` and `src/main/java/frc/robot/commands/DriveManual.java` files to add support for distinguishing between poses on our side and the opposing side of the field. The most important changes involve updating the pose lists and methods to incorporate this new distinction.

Updates to pose lists:

* [`Constants.java`](diffhunk://#diff-ea1fc0a250d9f1ec245395d6ededa6e0eeec69c1ffaa359273a1bafddd557811L678-R681): Renamed `BLUE_CAGE_POSES` and `RED_CAGE_POSES` to `OUR_SIDE_BLUE_CAGE_POSES` and `OUR_SIDE_RED_CAGE_POSES`, respectively. Added new lists for `OPPOSING_SIDE_BLUE_CAGE_POSES` and `OPPOSING_SIDE_RED_CAGE_POSES`.

New methods for opposing side poses:

* [`Constants.java`](diffhunk://#diff-ea1fc0a250d9f1ec245395d6ededa6e0eeec69c1ffaa359273a1bafddd557811R714-R718): Added `getOpposingSideCagePoses` method to calculate the opposing side pose from a given pose.
* [`Constants.java`](diffhunk://#diff-ea1fc0a250d9f1ec245395d6ededa6e0eeec69c1ffaa359273a1bafddd557811L743-R773): Added methods `getOpposingSideBlueCagePoses` and `getOpposingSideRedCagePoses` to generate lists of opposing side cage poses.

Updates to getter methods for cage positions:

* [`Constants.java`](diffhunk://#diff-ea1fc0a250d9f1ec245395d6ededa6e0eeec69c1ffaa359273a1bafddd557811L823-R870): Updated `getCagePositions` method to `getBlueCagePositions`, `getRedCagePositions`, and `getAllCagePositions` to support the new distinction between our side and the opposing side.

Integration with `DriveManual`:

* [`DriveManual.java`](diffhunk://#diff-a2a46d9ac2658cd3554f139a3f28a43043423b4d98066992cea902af9d7394d7R223-R229): Modified to use the new `getAllCagePositions` method, determining whether the robot is on the opposing side based on its x-coordinate.